### PR TITLE
Update requirements "h5py" missing in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ This repositry is under the construction.
 + Pillow (4.2.1)
 + Pandas (0.18.0)
 + Scikit-learn (0.19.0)
++ h5py (2.7.1)
 + model's weight (download it from [here](https://drive.google.com/open?id=0B90WglS_AQWebjBleG5uRXpmbUE) and place it in dir `model`.)
 ## How to use
 please change the line 15 of `output.py `


### PR DESCRIPTION
Executing output.py returns the following error:

```
$ python output.py                                                                                              v8.8.1 | 01:08 
Using TensorFlow backend.
/usr/lib/python3.6/importlib/_bootstrap.py:219: RuntimeWarning: compiletime version 3.5 of module 'tensorflow.python.framework.fast_tensor_util' does not match runtime version 3.6
  return f(*args, **kwds)
2017-11-13 13:11:08.607633: I tensorflow/core/platform/cpu_feature_guard.cc:137] Your CPU supports instructions that this TensorFlow binary was not compiled to use: SSE4.1 SSE4.2 AVX AVX2 FMA
Traceback (most recent call last):
  File "output.py", line 38, in <module>
    model.load_weights(weight_path)
  File "/usr/lib/python3.6/site-packages/keras/engine/topology.py", line 2615, in load_weights
    raise ImportError('`load_weights` requires h5py.')
ImportError: `load_weights` requires h5py.
```
Adding h5py (2.7.1) to requirements list fix the issue